### PR TITLE
fix: serialization of kwargs

### DIFF
--- a/taskqueue/registered_task.py
+++ b/taskqueue/registered_task.py
@@ -34,8 +34,9 @@ class Meta(type):
         return cls
 
 class RegisteredTask(with_metaclass(Meta)):
-    def __init__(self, *arg_values):
+    def __init__(self, *arg_values, **kwarg_values):
         self._args = OrderedDict(zip(self._arg_names, arg_values))
+        self._args.update(kwarg_values)
 
     @classmethod
     def deserialize(cls, base64data):
@@ -87,7 +88,7 @@ class PrintTask(RegisteredTask):
             print(self)
 
 class MockTask(RegisteredTask):
-    def __init__(self, *args):
-        super(MockTask, self).__init__()
+    def __init__(self, **kwargs):
+        super(MockTask, self).__init__(**kwargs)
     def execute(self):
         pass

--- a/test/test_taskqueue.py
+++ b/test/test_taskqueue.py
@@ -23,6 +23,15 @@ QTYPES = ('appengine', 'aws')#, 'google')
 
 QURL = 'https://sqs.us-east-1.amazonaws.com/098703261575/wms-test-pull-queue'
 
+def test_task_creation():
+  task = MockTask(this="is", a=[1, 4, 2], simple={"test": "to", "check": 4},
+               serialization=('i', 's', 's', 'u', 'e', 's'), with_kwargs=None)
+  task_str = task.serialize()
+  assert task_str == '{"this": "is", "a": [1, 4, 2], ' \
+                     '"simple": {"test": "to", "check": 4}, ' \
+                     '"serialization": ["i", "s", "s", "u", "e", "s"], ' \
+                     '"with_kwargs": null, "class": "MockTask"}'
+
 def test_get():
   global QUEUE_NAME
 
@@ -102,5 +111,5 @@ def test_local_taskqueue():
   with LocalTaskQueue(parallel=True, progress=False) as tq:
     for i in range(20000):
       tq.insert(
-        MockTask(i)
+        MockTask(arg=i)
       )


### PR DESCRIPTION
Allows `kwargs` for classes inheriting from `RegisteredTask`. 