### PR TITLE
sets version to string to allow import

### DIFF
--- a/taskqueue/__init__.py
+++ b/taskqueue/__init__.py
@@ -5,4 +5,4 @@ from .secrets import (
   PROJECT_NAME, AWS_DEFAULT_REGION
 )
 
-__version__ = 0.9.0
+__version__ = "0.9.0"


### PR DESCRIPTION
importing the package raises an error if __version__ isn't a string