### PR TITLE
feat: automatic multiprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,18 +213,22 @@ with ProcessPoolExecutor(max_workers=2) as execute:
 If you insist on wanting to pass generators to your subprocesses, you can use iterators instead. The construction above allows us to write the generator call up front, pass only a few primatives through the pickling process, and transparently call the generator on the other side. We can even support the `len()` function which is not available for generators.
 
 ```python
-# Listing 8: EZ Multiprocessing
+# Listing 8: Easy Multiprocessing
 
 import gevent.monkey 
-gevent.monkey.patch_all()
-from taskqueue import parallel_upload
+gevent.monkey.patch_all(thread=False)
+import copy
+from taskqueue import GreenTaskQueue
 
 class PrintTaskIterator(object):
   def __init__(self, start, end):
     self.start = start 
     self.end = end 
   def __getitem__(self, slc):
-    return PrintTaskIterator(self.start + slc.start, self.end + slc.stop)
+    itr = copy.deepcopy(self)
+    itr.start = self.start + slc.start 
+    itr.end = self.start + slc.stop
+    return itr
   def __len__(self):
     return self.end - self.start
   def __iter__(self):
@@ -234,6 +238,9 @@ class PrintTaskIterator(object):
 tq = GreenTaskQueue('sqs-queue-name')
 tq.insert_all(PrintTaskIterator(0,200), parallel=2)
 ```
+
+If you design your iterators such that the slice operator works, TaskQueue can
+automatically resection the iterator such that it can be fed to multiple processes. Notably, we don't return `PrintTaskIterator(self.start+slc.start, self.start+slc.stop)` because it triggers an endless recursion during pickling. However, the runtime copy implementation above sidesteps this issue. Internally, `PrintTaskIterator(0,200)` will be turned into `[ PrintTaskIterator(0,100), PrintTaskIterator(100,200) ]`. We also perform tracking of exceptions raised by child processes in a queue. `gevent.monkey.patch_all(thread=False)` was necessary to avoid multiprocess hanging.
 
 [1] You can't pass generators in CPython but [you can pass iterators](https://stackoverflow.com/questions/1939015/singleton-python-generator-or-pickle-a-python-generator/1939493#1939493). You can pass generators if you use Pypy or Stackless Python.
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,28 @@ with ProcessPoolExecutor(max_workers=2) as execute:
 
 If you insist on wanting to pass generators to your subprocesses, you can use iterators instead. The construction above allows us to write the generator call up front, pass only a few primatives through the pickling process, and transparently call the generator on the other side. We can even support the `len()` function which is not available for generators.
 
+```python
+# Listing 8: EZ Multiprocessing
+
+import gevent.monkey 
+gevent.monkey.patch_all()
+from taskqueue import parallel_upload
+
+class PrintTaskIterator(object):
+  def __init__(self, start, end):
+    self.start = start 
+    self.end = end 
+  def __getitem__(self, slc):
+    return PrintTaskIterator(self.start + slc.start, self.end + slc.stop)
+  def __len__(self):
+    return self.end - self.start
+  def __iter__(self):
+    for i in range(self.start, self.end):
+      yield PrintTask(i)
+
+tq = GreenTaskQueue('sqs-queue-name')
+tq.insert_all(PrintTaskIterator(0,200), parallel=2)
+```
 
 [1] You can't pass generators in CPython but [you can pass iterators](https://stackoverflow.com/questions/1939015/singleton-python-generator-or-pickle-a-python-generator/1939493#1939493). You can pass generators if you use Pypy or Stackless Python.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cloud-volume>=0.20.2
 gevent
 numpy>=1.13.1
+pathos
 pytest>=3.3.1
 pbr
 -e git+https://github.com/seung-lab/tqdm.git#egg=tqdm

--- a/taskqueue/__init__.py
+++ b/taskqueue/__init__.py
@@ -1,5 +1,8 @@
 from .registered_task import RegisteredTask, MockTask, PrintTask
-from .taskqueue import TaskQueue, GreenTaskQueue, MockTaskQueue, LocalTaskQueue, upload
+from .taskqueue import (
+  TaskQueue, GreenTaskQueue, MockTaskQueue, LocalTaskQueue, 
+  multiprocess_upload
+)
 from .secrets import (
   QUEUE_NAME, TEST_QUEUE_NAME, QUEUE_TYPE, 
   PROJECT_NAME, AWS_DEFAULT_REGION

--- a/taskqueue/taskqueue.py
+++ b/taskqueue/taskqueue.py
@@ -534,7 +534,11 @@ class MockTaskQueue(object):
     task.execute(*args, **kwargs)
     del task
 
-  def insert_all(self, tasks, args=[], kwargs={}, delay_seconds=0, total=None):
+  def insert_all(
+    self, tasks, args=[], kwargs={}, 
+    delay_seconds=0, total=None,
+    parallel=1
+  ):
     for task in tasks:
       self.insert(task, args=args, kwargs=kwargs)
 
@@ -573,10 +577,17 @@ class LocalTaskQueue(object):
 
   def insert_all(
       self, tasks, args=[], kwargs={}, 
-      delay_seconds=0, total=None
+      delay_seconds=0, total=None,
+      parallel=None, progress=True
     ):
+
+    if parallel is None:
+      parallel = self.parallel
+
     for task in tasks:
       self.queue.append( (task, args, kwargs) )
+
+    self._process(progress)
 
   def wait(self, progress=None):
     self._process(progress)

--- a/taskqueue/taskqueue.py
+++ b/taskqueue/taskqueue.py
@@ -319,7 +319,7 @@ class TaskQueue(SuperTaskQueue, ThreadedQueue):
           pass
 
         if len(batch) == 0:
-          raise StopIteration
+          break
 
         yield batch
 
@@ -454,7 +454,7 @@ class GreenTaskQueue(SuperTaskQueue):
           pass
 
         if len(batch) == 0:
-          raise StopIteration
+          break
 
         yield batch
 


### PR DESCRIPTION
- Fixes bug where StopIteration triggers a RuntimeError 
- Adds `tq.insert_all(..., parallel=N)`
- Uses pathos for multiprocessing to allow more creative data structures to pass through.
- Collect errors in multiprocessing and raise them at the end.
- Refactor insert_all to remove duplicate code.