### PR TITLE
redesign(BREAKING): replace useless log_fn with before_fn and after_fn

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,13 @@
 CHANGES
 =======
 
+0.15.0
+------
+
+* release: 0.15.0
+* feat: support progress bars for MockTaskQueue
+* fix: accomodate change to Markdown detection on pypi
+
 0.14.5
 ------
 


### PR DESCRIPTION
log_fn wasn't working, and it doesn't really make sense to disable
the print statements. It does make sense to give access to the task
though.