### PR TITLE
BREAKING: drop python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 python:
-- '2.7'
 - '3.5'
 - '3.6'
-- '3.7-dev'
-- '3.8-dev'
-dist: trusty
+- '3.7'
+- '3.8'
 before_install:
 - PYTHON_MAJOR_VERSION=`echo $TRAVIS_PYTHON_VERSION | head -c 1`
 - if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then sudo apt-get install python3-pip; fi

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,16 @@
 CHANGES
 =======
 
+* test: fix travis
+* fix: support py27 with scandir pkg
+* feat: FileQueue + big redesign of TaskQueue (#24)
+
+1.0.0
+-----
+
+* release(1.0.0): add before\_fn and after\_fn to poll
+* redesign(BREAKING): replace useless log\_fn with before\_fn and after\_fn (#21)
+
 0.15.0
 ------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ pbr
 tenacity
 tqdm
 requests>2,<3
-scandir

--- a/taskqueue/file_queue_api.py
+++ b/taskqueue/file_queue_api.py
@@ -10,11 +10,6 @@ import shutil
 import uuid
 import time
 
-try:
-  from os import scandir
-except ImportError:
-  from scandir import scandir
-
 import tenacity
 
 from .registered_task import totask, totaskid
@@ -277,7 +272,7 @@ class FileQueueAPI(object):
   def release_all(self):
     """Voids all leases and sets all tasks to available."""
     now = nowfn()
-    for file in scandir(self.queue_path):
+    for file in os.scandir(self.queue_path):
       if get_timestamp(file.name) < now:
         continue
 
@@ -324,7 +319,7 @@ class FileQueueAPI(object):
       return (int(timestamp), filename)
 
     now = nowfn()
-    files = ( fmt(direntry) for direntry in scandir(self.queue_path) )
+    files = ( fmt(direntry) for direntry in os.scandir(self.queue_path) )
 
     leasable_files = []
 
@@ -389,8 +384,8 @@ class FileQueueAPI(object):
 
   def purge(self):
     all_files = itertools.chain(
-      scandir(self.queue_path), 
-      scandir(self.movement_path)
+      os.scandir(self.queue_path), 
+      os.scandir(self.movement_path)
     )
     for file in all_files:
       try:
@@ -410,10 +405,10 @@ class FileQueueAPI(object):
       with open(path, 'rt') as f:
         return f.read()
 
-    return ( read(f.path) for f in scandir(self.queue_path) )
+    return ( read(f.path) for f in os.scandir(self.queue_path) )
 
   def __len__(self):
-    return functools.reduce(operator.add, ( 1 for f in scandir(self.queue_path) ), 0)
+    return functools.reduce(operator.add, ( 1 for f in os.scandir(self.queue_path) ), 0)
       
       
 


### PR DESCRIPTION
py27 doesn't support scandir without extra package support and it's being a pain. It's already July 2020 and py27 died in January 2020. Maybe I shouldn't continue this Weekend at Bernie's farce any longer.