### PR TITLE
feat: queueable functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
 CHANGES
 =======
 
+2.6.0
+-----
+
+* release(2.6.0): adds number leased to ptq status
+* feat(cli): add number of leased tasks to status for filequeue
+
 2.5.1
 -----
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ click
 gevent
 google-auth>=1.10.0
 google-cloud-core>=1.1.0
+orjson
 numpy>=1.13.1
 pathos
 pbr

--- a/taskqueue/__init__.py
+++ b/taskqueue/__init__.py
@@ -3,5 +3,6 @@ from .taskqueue import (
   TaskQueue, MockTaskQueue, GreenTaskQueue, LocalTaskQueue, 
   multiprocess_upload, QueueEmptyError, totask, UnsupportedProtocolError
 )
+from .queueablefns import queueable
 
 __version__ = '2.6.0'

--- a/taskqueue/__init__.py
+++ b/taskqueue/__init__.py
@@ -3,6 +3,6 @@ from .taskqueue import (
   TaskQueue, MockTaskQueue, GreenTaskQueue, LocalTaskQueue, 
   multiprocess_upload, QueueEmptyError, totask, UnsupportedProtocolError
 )
-from .queueablefns import queueable
+from .queueablefns import queueable, FunctionTask
 
 __version__ = '2.6.0'

--- a/taskqueue/file_queue_api.py
+++ b/taskqueue/file_queue_api.py
@@ -12,7 +12,6 @@ import time
 
 import tenacity
 
-from .registered_task import totask, totaskid
 from .lib import mkdir, jsonify, toiter, STRING_TYPES, sip, toabs
 
 retry = tenacity.retry(

--- a/taskqueue/lib.py
+++ b/taskqueue/lib.py
@@ -34,6 +34,15 @@ def toabs(path):
   path = os.path.expanduser(path)
   return os.path.abspath(path)
 
+def nvl(*args):
+  """Return the leftmost argument that is not None."""
+  if len(args) < 2:
+    raise IndexError("nvl takes at least two arguments.")
+  for arg in args:
+    if arg is not None:
+      return arg
+  return args[-1]
+
 def mkdir(path):
   path = toabs(path)
 

--- a/taskqueue/queueablefns.py
+++ b/taskqueue/queueablefns.py
@@ -70,6 +70,8 @@ class FunctionTask():
     return getattr(self, self._order[idx])
   def __setitem__(self, idx, value):
     setattr(self, self._order[idx], value)
+  def __iter__(self):
+    raise TypeError("FunctionTask is not an iterable.")
   def payload(self):
     return FunctionTaskLite(self.key, self.args, self.kwargs, self.id)
   def execute(self, *args, **kwargs):
@@ -80,7 +82,7 @@ class FunctionTask():
       raise UnregisteredFunctionError("{} is not registered as a queuable function.".format(self.key))
     return partial(fn, *self.args, **self.kwargs)
   def __repr__(self):
-    return "FunctionTask({},{},{},{})".format(self.key, self.args, self.kwargs, self.id)
+    return "FunctionTask({},{},{},\"{}\")".format(self.key, self.args, self.kwargs, self.id)
   def __call__(self):
     return self.tofunc()()
 
@@ -132,13 +134,6 @@ def argsokay(fn, args, kwargs):
       return False
 
   return True
-
-def deserialize(data):
-  if type(data) is bytes:
-    data = data.decode('utf8')
-  if isinstance(data, str):
-    data = orjson.loads(data)
-  return FunctionTask(*data)
 
 def queueable(fn):
   REGISTRY[(fn.__module__, fn.__name__)] = fn

--- a/taskqueue/queueablefns.py
+++ b/taskqueue/queueablefns.py
@@ -1,0 +1,144 @@
+from collections import namedtuple
+import functools
+import inspect
+import orjson
+import copy
+import re
+from collections import OrderedDict
+from functools import partial
+
+import numpy as np
+
+REGISTRY = {}
+FunctionTask = namedtuple("FunctionTask", [ "key", "args", "kwargs", "id" ])
+
+class UnregisteredFunctionError(BaseException):
+  pass
+
+def totask(data, ident=-1):
+  if isinstance(data, FunctionTask):
+    return data
+  if isinstance(data, partial) or callable(data):
+    return serialize(data)
+
+  if type(data) is bytes:
+    data = data.decode('utf8')
+  if isinstance(data, six.string_types):
+    data = orjson.loads(data)
+  data[3] = ident
+  return FunctionTask(*data) 
+
+def tofunc(task):
+  if callable(task):
+    return task
+
+  fn = REGISTRY.get(task[0], None)
+  if fn is None:
+    raise UnregisteredFunctionError("{} is not registered as a queuable function.".format(task.key))
+  return partial(fn, *task[1], **task[2])
+
+def execute(task):
+  tofunc(task)()
+
+# class FunctionTask():
+#   __slots__ = ['key', 'args', 'kwargs', 'id']
+#   def __init__(self, key, args, kwargs, id=None):
+#     self.key = tuple(key)
+#     self.args = args
+#     self.kwargs = kwargs
+#     self.id = id
+#     self._order = ('key', 'args', 'kwargs', 'id')
+#   def __getitem__(self, idx):
+#     return getattr(self, self._order[idx])
+#   def __setitem__(self, idx, value):
+#     setattr(self, self._order[idx], value)
+#   def serialize(self):
+#     return serialize(partial(REGISTRY[self.key], *self.args, **self.kwargs))
+#   def execute(self):
+#     self()
+#   def __call__(self):
+#     function(self)()
+
+def jsonifyable(obj):
+  if hasattr(obj, 'serialize') and callable(obj.serialize):
+    return obj.serialize()
+
+  try:
+    iter(obj)
+  except TypeError:
+    return obj
+
+  if isinstance(obj, bytes):
+    return obj.decode('utf8')
+  elif isinstance(obj, str):
+    return obj
+
+  if isinstance(obj, list) or isinstance(obj, tuple):
+    return [ jsonifyable(x) for x in obj ] 
+
+  for key, val in six.iteritems(obj):
+    if isinstance(val, np.ndarray):
+      obj[key] = val.tolist()
+    elif isinstance(val, dict):
+      obj[key] = jsonifyable(val)
+    elif isinstance(val, list):
+      obj[key] = [ jsonifyable(x) for x in val ]
+    elif hasattr(val, 'serialize') and callable(val.serialize):
+      obj[key] = val.serialize()
+
+  return obj
+
+def argsokay(fn, args, kwargs):
+  spec = inspect.getfullargspec(fn)
+
+  kwargct = 0
+  sargs = set(spec.args)
+  for name in kwargs.keys():
+    kwargct += (name in sargs)
+
+  if len(spec.args) - len(spec.defaults) <= len(args) + kwargct <= len(spec.args):
+    return False
+
+  for name in kwargs.keys():
+    if not (name in sargs) and not (name in spec.kwonlyargs):
+      return False
+
+  return True
+
+def serialize(fn, id=None):
+  if isinstance(fn, FunctionTask):
+    return fn.serialize()
+
+  if not isinstance(fn, partial) and not callable(fn):
+    raise ValueError("Must be a partial or other callable.")
+
+  args = []
+  kwargs = {}
+  rawfn = fn
+  while isinstance(rawfn, partial):
+    args += rawfn.args
+    kwargs.update(rawfn.keywords)
+    rawfn = rawfn.func
+
+  if not argsokay(rawfn, args, kwargs):
+    raise ValueError("{} didn't get valid arguments. Got: {}, {}. Expected: {}".format(
+      rawfn, args, kwargs, inspect.getfullargspec(rawfn)
+    ))
+
+  return FunctionTask(
+    (rawfn.__module__, rawfn.__name__), 
+    jsonifyable(args), 
+    jsonifyable(kwargs),
+    id
+  )
+
+def deserialize(data):
+  if type(data) is bytes:
+    data = data.decode('utf8')
+  if isinstance(data, six.string_types):
+    data = orjson.loads(data)
+  return FunctionTask(*data)
+
+def queueable(fn):
+  REGISTRY[(fn.__module__, fn.__name__)] = fn
+  return fn

--- a/taskqueue/queueablefns.py
+++ b/taskqueue/queueablefns.py
@@ -23,7 +23,7 @@ def totask(data, ident=-1):
 
   if type(data) is bytes:
     data = data.decode('utf8')
-  if isinstance(data, six.string_types):
+  if isinstance(data, str):
     data = orjson.loads(data)
   data[3] = ident
   return FunctionTask(*data) 
@@ -76,7 +76,7 @@ def jsonifyable(obj):
   if isinstance(obj, list) or isinstance(obj, tuple):
     return [ jsonifyable(x) for x in obj ] 
 
-  for key, val in six.iteritems(obj):
+  for key, val in obj.items():
     if isinstance(val, np.ndarray):
       obj[key] = val.tolist()
     elif isinstance(val, dict):
@@ -91,12 +91,15 @@ def jsonifyable(obj):
 def argsokay(fn, args, kwargs):
   spec = inspect.getfullargspec(fn)
 
+  sargs = spec.args or []
+  sdefaults = spec.defaults or []
+
   kwargct = 0
-  sargs = set(spec.args)
+  sargs = set(sargs)
   for name in kwargs.keys():
     kwargct += (name in sargs)
 
-  if len(spec.args) - len(spec.defaults) <= len(args) + kwargct <= len(spec.args):
+  if not (len(sargs) - len(sdefaults) <= len(args) + kwargct <= len(sargs)):
     return False
 
   for name in kwargs.keys():
@@ -108,7 +111,6 @@ def argsokay(fn, args, kwargs):
 def serialize(fn, id=None):
   if isinstance(fn, FunctionTask):
     return fn.serialize()
-
   if not isinstance(fn, partial) and not callable(fn):
     raise ValueError("Must be a partial or other callable.")
 
@@ -135,7 +137,7 @@ def serialize(fn, id=None):
 def deserialize(data):
   if type(data) is bytes:
     data = data.decode('utf8')
-  if isinstance(data, six.string_types):
+  if isinstance(data, str):
     data = orjson.loads(data)
   return FunctionTask(*data)
 

--- a/taskqueue/queueables.py
+++ b/taskqueue/queueables.py
@@ -1,0 +1,40 @@
+from functools import partial
+
+import orjson
+
+from .queueablefns import totask as qtotask, FunctionTask 
+from .registered_task import totask as rtotask, RegisteredTask
+
+def totask(task):
+  if isinstance(task, (FunctionTask, RegisteredTask)):
+    return task
+
+  if type(task) is bytes:
+    task = task.decode('utf8')
+  if isinstance(task, str):
+    task = orjson.loads(task)
+
+  ident = -1
+  if isinstance(task, dict):
+    ident = task.get('id', -1)
+    if 'payload' in task:
+      task = task['payload']
+
+  if isinstance(task, list):
+    task[3] = ident
+    return FunctionTask(*task)
+  elif isinstance(task, dict):
+    return rtotask(task, ident)
+  elif isinstance(task, partial) or callable(task):
+    return qtotask(task, ident)
+
+  raise ValueError("Unable to convert {} into a task object.".format(task))
+
+def totaskid(taskid):
+  if hasattr(taskid, 'id'):
+    return taskid.id
+  elif 'id' in taskid:
+    return taskid['id']
+  elif isinstance(taskid, (list, tuple)):
+    return taskid[3]
+  return taskid

--- a/taskqueue/queueables.py
+++ b/taskqueue/queueables.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import orjson
 
-from .queueablefns import totask as qtotask, FunctionTask 
+from .queueablefns import totask as qtotask, FunctionTask, tofunc
 from .registered_task import totask as rtotask, RegisteredTask
 
 def totask(task):

--- a/taskqueue/queueables.py
+++ b/taskqueue/queueables.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import orjson
 
-from .queueablefns import totask as qtotask, FunctionTask, tofunc
+from .queueablefns import totask as qtotask, FunctionTask, FunctionTaskLite, tofunc
 from .registered_task import totask as rtotask, RegisteredTask
 
 def totask(task):
@@ -20,7 +20,9 @@ def totask(task):
     if 'payload' in task:
       task = task['payload']
 
-  if isinstance(task, list):
+  if isinstance(task, FunctionTaskLite):
+    return FunctionTask(*task)
+  elif isinstance(task, list):
     task[3] = ident
     return FunctionTask(*task)
   elif isinstance(task, dict):

--- a/taskqueue/registered_task.py
+++ b/taskqueue/registered_task.py
@@ -1,7 +1,8 @@
 import six
 from six import with_metaclass
+import functools
 import inspect
-import json
+import orjson
 import copy
 import re
 from collections import OrderedDict
@@ -11,39 +12,17 @@ import numpy as np
 
 REGISTRY = {}
 
-def totask(task):
-  if isinstance(task, RegisteredTask):
-    return task
-
-  if type(task) is bytes:
-    task = task.decode('utf8')
-
-  if isinstance(task, six.string_types):
-    task = json.loads(task)
-
-  ident = task.get('id', -1)
-
-  if 'payload' in task:
-    task = task['payload']
-
+def totask(task, ident=-1):
   taskobj = deserialize(task)
   taskobj._id = ident
   return taskobj
-
-def totaskid(taskid):
-  if isinstance(taskid, RegisteredTask):
-    return taskid.id
-  elif 'id' in taskid:
-    return taskid['id']
-    
-  return taskid
 
 def deserialize(data):
   if type(data) is bytes:
     data = data.decode('utf8')
 
   if isinstance(data, six.string_types):
-    data = json.loads(data)
+    data = orjson.loads(data)
 
   name = data['class']
   target_class = REGISTRY[name]

--- a/taskqueue/taskqueue.py
+++ b/taskqueue/taskqueue.py
@@ -23,7 +23,7 @@ from .file_queue_api import FileQueueAPI
 from .paths import extract_path, mkpath
 from .scheduler import schedule_jobs
 from .queueables import totask, totaskid
-from .queueablefns import serialize as serializefn
+from .queueablefns import FunctionTask
 
 def totalfn(iterator, total):
   if total is not None:
@@ -167,18 +167,15 @@ class TaskQueue(object):
     except:
       batch_size = 1
     
-    def payload(task):
-      if hasattr(task, 'payload'):
-        return task.payload()
-      return serializefn(task)
-
     bodies = (
       {
-        "payload": payload(task),
+        "payload": totask(task).payload(),
         "queueName": self.path.path,
       } 
       for task in tasks
     )
+
+
 
     ct = [ 0 ] # using a list instead of a raw number to use pass-by-reference
     ct_lock = threading.Lock()

--- a/taskqueue/taskqueue.py
+++ b/taskqueue/taskqueue.py
@@ -23,6 +23,7 @@ from .file_queue_api import FileQueueAPI
 from .paths import extract_path, mkpath
 from .scheduler import schedule_jobs
 from .queueables import totask, totaskid
+from .queueablefns import serialize as serializefn
 
 def totalfn(iterator, total):
   if total is not None:
@@ -169,7 +170,7 @@ class TaskQueue(object):
     def payload(task):
       if hasattr(task, 'payload'):
         return task.payload()
-      return queueablefns.serialize(task)
+      return serializefn(task)
 
     bodies = (
       {
@@ -285,9 +286,7 @@ class TaskQueue(object):
     if self.path.protocol == "sqs":
       raise UnsupportedProtocolError("SQS could enter an infinite loop from this method.")
 
-    x = [ task for task in iter(self.api) ]
-    print(x)
-    return ( totask(task) for task in x )
+    return ( totask(task) for task in iter(self.api) )
 
   def poll(
     self, lease_seconds=LEASE_SECONDS,  

--- a/taskqueue/taskqueue.py
+++ b/taskqueue/taskqueue.py
@@ -430,10 +430,12 @@ class LocalTaskQueue(object):
       delay_seconds=0, total=None,
       parallel=None, progress=True
     ):
+    tasks = toiter(tasks)
     for task in tasks:
       args, kwargs = [], {}
       if isinstance(task, tuple):
         task, args, kwargs = task
+      task = totask(task)
       task = {
         'payload': task.payload(),
         'id': -1,

--- a/test/test_taskqueue.py
+++ b/test/test_taskqueue.py
@@ -11,7 +11,8 @@ import pytest
 import taskqueue
 from taskqueue import queueable, FunctionTask, RegisteredTask, TaskQueue, MockTask, PrintTask, LocalTaskQueue
 from taskqueue.paths import ExtractedPath, mkpath
-from taskqueue.queueablefns import serialize, tofunc, UnregisteredFunctionError
+from taskqueue.queueables import totask
+from taskqueue.queueablefns import tofunc, UnregisteredFunctionError
 
 @pytest.fixture(scope='function')
 def aws_credentials():
@@ -57,19 +58,19 @@ def printfn(txt):
 
 def test_task_creation_fns():
   task = partial(printfn, "hello world")
-  task = serialize(task)
+  task = totask(task)
 
   assert task.key == ("test_taskqueue", "printfn")
   assert task.args == ["hello world"]
   assert task.kwargs == {}
-  assert task.id == None
+  assert task.id == -1
 
   fn = tofunc(task)
   assert fn() == 1337
 
   try:
-    tofunc(FunctionTask(("fake", "fake"), [], {}, None))
-    assert False, "Should not have been able to create this function."
+    FunctionTask(("fake", "fake"), [], {}, None)()
+    assert False, "Should not have been able to call this function."
   except UnregisteredFunctionError:
     pass
 

--- a/test/test_taskqueue.py
+++ b/test/test_taskqueue.py
@@ -1,3 +1,4 @@
+from functools import partial
 import json
 import os
 import time
@@ -8,9 +9,9 @@ from six.moves import range
 import pytest
 
 import taskqueue
-from taskqueue import RegisteredTask, TaskQueue, MockTask, PrintTask, LocalTaskQueue
+from taskqueue import queueable, FunctionTask, RegisteredTask, TaskQueue, MockTask, PrintTask, LocalTaskQueue
 from taskqueue.paths import ExtractedPath, mkpath
-
+from taskqueue.queueablefns import serialize, tofunc, UnregisteredFunctionError
 
 @pytest.fixture(scope='function')
 def aws_credentials():
@@ -49,7 +50,30 @@ class ExecutePrintTask(RegisteredTask):
     print(wow + wow2)
     return wow + wow2
 
-def test_task_creation():
+@queueable
+def printfn(txt):
+  print(txt)
+  return 1337
+
+def test_task_creation_fns():
+  task = partial(printfn, "hello world")
+  task = serialize(task)
+
+  assert task.key == ("test_taskqueue", "printfn")
+  assert task.args == ["hello world"]
+  assert task.kwargs == {}
+  assert task.id == None
+
+  fn = tofunc(task)
+  assert fn() == 1337
+
+  try:
+    tofunc(FunctionTask(("fake", "fake"), [], {}, None))
+    assert False, "Should not have been able to create this function."
+  except UnregisteredFunctionError:
+    pass
+
+def test_task_creation_classes():
   task = MockTask(this="is", a=[1, 4, 2], simple={"test": "to", "check": 4},
                serialization=('i', 's', 's', 'u', 'e', 's'), wow=4, with_kwargs=None)
   task.wow = 5
@@ -110,6 +134,20 @@ def test_single_threaded_insertion(sqs, protocol):
   tq.insert(( PrintTask() for i in range(n_inserts) ))
 
   assert all(map(lambda x: type(x) == PrintTask, tq.list()))
+
+  tq.purge()
+
+@pytest.mark.parametrize('protocol', PROTOCOL)
+def test_single_threaded_insertion_fns(sqs, protocol):
+  path = getpath(protocol) 
+  tq = TaskQueue(path, n_threads=0)
+
+  tq.purge()
+  
+  n_inserts = 5
+  tq.insert(( partial(printfn, "hello world " + str(i)) for i in range(n_inserts) ))
+
+  assert all(map(lambda x: isinstance(x, FunctionTask), tq.list()))
 
   tq.purge()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py27,py36,py37,py38
+
+[testenv]
+platform = darwin
+deps = 
+	-rrequirements.txt
+	-rrequirements_dev.txt
+
+commands = 
+    python setup.py develop
+	python -m pytest -v -x test


### PR DESCRIPTION
Backwards compatible.

Instead of needing to create a class for the `RegisteredTask` class you do the following:

```python
from functools import partial
from taskqueue import TaskQueue, queueable

@queueable
def prt(txt):
  print(txt)

tasks = ( partial(prt,i) for i in range(1000) )
tq = TaskQueue('fq:///tmp/removeme/test-queue')
tq.insert(tasks, total=1000)
```