### PR TITLE
fix: progress bar overestimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ The task queue uses your CloudVolume secrets located in `$HOME/.cloudvolume/secr
 
 ## Usage
 
-As of version 2.7.0, there are two ways to create a queueable task. The new way is simpler and probably preferred.
+As of version 2.7.0, there are two ways to create a queueable task. The new way is simpler and probably preferred. 
+
+*MacOS Only: Note that proxy servers are disabled for parallel operation due to libdispatch being not fork-safe.*
 
 ### New School: Queueable Functions
 

--- a/taskqueue/aws_queue_api.py
+++ b/taskqueue/aws_queue_api.py
@@ -162,6 +162,8 @@ class AWSTaskQueueAPI(object):
     except botocore.exceptions.ClientError as err:
       pass
 
+    return 1
+
   def tally(self):
     pass
 

--- a/taskqueue/file_queue_api.py
+++ b/taskqueue/file_queue_api.py
@@ -364,7 +364,10 @@ class FileQueueAPI(object):
     try:
       fd = read_lock_file(open(movements_file_path, 'rt'))
     except FileNotFoundError:
-      return
+      # if it doesn't exist we still want to count this 
+      # as a delete request succeeded b/c its purpose was 
+      # achieved and the progress bar should increment.
+      return 1 
 
     filenames = fd.read().split('\n')
     fd.close()
@@ -385,6 +388,8 @@ class FileQueueAPI(object):
       os.remove(movements_file_path)
     except FileNotFoundError:
       pass
+
+    return 1
 
   def tally(self):
     with open(self.completions_path, 'ba') as f:

--- a/taskqueue/scheduler.py
+++ b/taskqueue/scheduler.py
@@ -25,9 +25,9 @@ def schedule_threaded_jobs(
   
   def updatefn(fn):
     def realupdatefn(iface):
-      res = fn()
-      pbar.update(batch_size)
-      results.append(res)
+      ct = fn()
+      pbar.update(ct)
+      results.append(ct) # cPython list append is thread safe
     return realupdatefn
 
   with ThreadedQueue(n_threads=concurrency) as tq:


### PR DESCRIPTION
fix: progress bar overestimate

We now measure the number of items processed rather than increment by `batch_size` each time which overestimated the final batch.

fix: no_proxy for MacOS

Grand Central Dispatch (libdispatch) is not fork-safe and is
called by urllib if proxying is possible. Therefore, we disable
proxies to avoid this issue.